### PR TITLE
Update whisper_diarize.py to use version 3.1

### DIFF
--- a/whisperplus/app.py
+++ b/whisperplus/app.py
@@ -56,6 +56,36 @@ def speaker_diarization(url, model_id, device, num_speakers, min_speaker, max_sp
     dialogue = format_speech_to_dialogue(output_text)
     return dialogue, audio_path
 
+def speaker_diarization_from_path(path):
+    """
+    Main function that downloads and converts a video to MP3 format, performs speech-to-text conversion using
+    a specified model, and returns the transcript along with the video path.
+
+    Args:
+        url (str): The URL of the video to download and convert.
+        model_id (str): The ID of the speech-to-text model to use.
+        language_choice (str): The language choice for the speech-to-text conversion.
+
+    Returns:
+        transcript (str): The transcript of the speech-to-text conversion.
+        video_path (str): The path of the downloaded video.
+    """
+
+    pipeline = ASRDiarizationPipeline.from_pretrained(
+        asr_model=model_id,
+        diarizer_model="pyannote/speaker-diarization-3.1",
+        use_auth_token=False,
+        chunk_length_s=30,
+        device=device,
+    )
+    pipeline.to(torch.device("cuda"))
+    waveform, sample_rate = torchaudio.load(path)
+
+    with ProgressHook() as hook:
+      output_text = pipeline({"waveform": waveform, "sample_rate": sample_rate}, hook=hook)
+    return output_text
+
+
 
 def youtube_url_to_text_app():
     with gr.Blocks():

--- a/whisperplus/pipelines/whisper_diarize.py
+++ b/whisperplus/pipelines/whisper_diarize.py
@@ -26,7 +26,7 @@ class ASRDiarizationPipeline:
         cls,
         asr_model: Optional[str] = "openai/whisper-large-v3",
         *,
-        diarizer_model: Optional[str] = "pyannote/speaker-diarization",
+        diarizer_model: Optional[str] = "pyannote/speaker-diarization-3.1",
         chunk_length_s: Optional[int] = 30,
         use_auth_token: Optional[Union[str, bool]] = False,
         **kwargs,

--- a/whisperplus/pipelines/whisper_diarize.py
+++ b/whisperplus/pipelines/whisper_diarize.py
@@ -43,6 +43,21 @@ class ASRDiarizationPipeline:
         diarization_pipeline = Pipeline.from_pretrained(diarizer_model, use_auth_token=use_auth_token)
         return cls(asr_pipeline, diarization_pipeline)
 
+    def load_audio(self, audio_path: str):
+        waveform, sample_rate = torchaudio.load(audio_path)
+
+        # If the sample rate is different than the model's expected sample rate,
+        # resample it.
+        if sample_rate != self.sampling_rate:
+            transformation = torchaudio.transforms.Resample(orig_freq=sample_rate, new_freq=self.sampling_rate)
+            waveform = transformation(waveform)
+        
+        # Ensure the waveform is monaural (single channel) if it's not already
+        if waveform.size(0) > 1:
+            waveform = torchaudio.transforms.DownmixMono()(waveform)
+
+        return waveform.to(self.device), self.sampling_rate
+
     def __call__(
         self,
         inputs: Union[np.ndarray, List[np.ndarray]],


### PR DESCRIPTION
# Update Diarize .py to use version 3.1

## **Description**

Currently whisper-plus is using an older version of [speaker-diarization](https://huggingface.co/pyannote/speaker-diarization) that relies on pyannote-audio 2.1.1. The current version [is 3.1](https://huggingface.co/pyannote/speaker-diarization-3.1), which also uses pyannote-audio 3.1.0. Note that this [wouldn't change any requirements](https://github.com/TCU-ClassifAI/whisper-plus/blob/8659b526b05ae56420f9b6d7864d6b78165bab1b/requirements.txt#L8C1-L8C22).


### **Additional context**

The newer version has a significantly lower diarization error rate across many benchmarks. 
