### PR TITLE
Add speechbrain dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ ctransformers
 accelerate
 pre-commit==3.4.0
 autollm==0.1.9
+speechbrain

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ ctransformers
 accelerate
 pre-commit==3.4.0
 autollm==0.1.9
-speechbrain
+speechbrain==0.5.16


### PR DESCRIPTION
Adds `speechbrain` as a dependency in the `requirements.txt` file to address the ImportError issue related to 'speechbrain' not being installed. This change ensures that the necessary package is included in the project dependencies, aligning with the task to resolve the ImportError encountered during execution.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kadirnar/whisper-plus?shareId=1ae02a55-43c1-4f64-90e0-df69e6fb06ba).